### PR TITLE
Change package name from zip_forge to zipforge

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ It uses the `file` and `directory` methods to create files and directories withi
 ```java
 import java.nio.charset.StandardCharsets;
 
-import static io.github.helpermethod.zip_forge.ZipForge.createZipFile;
-import static io.github.helpermethod.zip_forge.ZipForge.file;
-import static io.github.helpermethod.zip_forge.ZipForge.directory;
+import static io.github.helpermethod.zipforge.ZipForge.createZipFile;
+import static io.github.helpermethod.zipforge.ZipForge.file;
+import static io.github.helpermethod.zipforge.ZipForge.directory;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 class ZipForgeDemo {
@@ -110,9 +110,9 @@ Archive:  demo.zip
 The same example written in Kotlin. Note that it uses the same API as the Java version.
 
 ```kotlin
-import io.github.helpermethod.zip_forge.ZipForge.createZipFile
-import io.github.helpermethod.zip_forge.ZipForge.directory
-import io.github.helpermethod.zip_forge.ZipForge.file
+import io.github.helpermethod.zipforge.ZipForge.createZipFile
+import io.github.helpermethod.zipforge.ZipForge.directory
+import io.github.helpermethod.zipforge.ZipForge.file
 import kotlin.io.path.Path
 
 fun main() {

--- a/pom.xml
+++ b/pom.xml
@@ -223,8 +223,8 @@
                         <configuration>
                             <module>
                                 <moduleInfo>
-                                    <name>io.github.helpermethod.zip_forge</name>
-                                    <exports>io.github.helpermethod.zip_forge</exports>
+                                    <name>io.github.helpermethod.zipforge</name>
+                                    <exports>io.github.helpermethod.zipforge</exports>
                                 </moduleInfo>
                             </module>
                             <overwriteExistingFiles>true</overwriteExistingFiles>

--- a/src/main/java/io/github/helpermethod/zipforge/DirectoryNode.java
+++ b/src/main/java/io/github/helpermethod/zipforge/DirectoryNode.java
@@ -1,4 +1,4 @@
-package io.github.helpermethod.zip_forge;
+package io.github.helpermethod.zipforge;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/io/github/helpermethod/zipforge/FileNode.java
+++ b/src/main/java/io/github/helpermethod/zipforge/FileNode.java
@@ -1,4 +1,4 @@
-package io.github.helpermethod.zip_forge;
+package io.github.helpermethod.zipforge;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/io/github/helpermethod/zipforge/Node.java
+++ b/src/main/java/io/github/helpermethod/zipforge/Node.java
@@ -1,4 +1,4 @@
-package io.github.helpermethod.zip_forge;
+package io.github.helpermethod.zipforge;
 
 import java.io.IOException;
 

--- a/src/main/java/io/github/helpermethod/zipforge/NodeGroup.java
+++ b/src/main/java/io/github/helpermethod/zipforge/NodeGroup.java
@@ -1,4 +1,4 @@
-package io.github.helpermethod.zip_forge;
+package io.github.helpermethod.zipforge;
 
 public interface NodeGroup {
     void addNodes();

--- a/src/main/java/io/github/helpermethod/zipforge/Visitor.java
+++ b/src/main/java/io/github/helpermethod/zipforge/Visitor.java
@@ -1,4 +1,4 @@
-package io.github.helpermethod.zip_forge;
+package io.github.helpermethod.zipforge;
 
 import java.io.IOException;
 

--- a/src/main/java/io/github/helpermethod/zipforge/ZipFileVisitor.java
+++ b/src/main/java/io/github/helpermethod/zipforge/ZipFileVisitor.java
@@ -1,4 +1,4 @@
-package io.github.helpermethod.zip_forge;
+package io.github.helpermethod.zipforge;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/io/github/helpermethod/zipforge/ZipForge.java
+++ b/src/main/java/io/github/helpermethod/zipforge/ZipForge.java
@@ -1,4 +1,4 @@
-package io.github.helpermethod.zip_forge;
+package io.github.helpermethod.zipforge;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 

--- a/src/main/java/io/github/helpermethod/zipforge/ZipForgeException.java
+++ b/src/main/java/io/github/helpermethod/zipforge/ZipForgeException.java
@@ -1,4 +1,4 @@
-package io.github.helpermethod.zip_forge;
+package io.github.helpermethod.zipforge;
 
 import java.io.IOException;
 

--- a/src/test/java/io/github/helpermethod/zipforge/ZipForgeTest.java
+++ b/src/test/java/io/github/helpermethod/zipforge/ZipForgeTest.java
@@ -1,8 +1,8 @@
-package io.github.helpermethod.zip_forge;
+package io.github.helpermethod.zipforge;
 
-import static io.github.helpermethod.zip_forge.ZipForge.createZipFile;
-import static io.github.helpermethod.zip_forge.ZipForge.directory;
-import static io.github.helpermethod.zip_forge.ZipForge.file;
+import static io.github.helpermethod.zipforge.ZipForge.createZipFile;
+import static io.github.helpermethod.zipforge.ZipForge.directory;
+import static io.github.helpermethod.zipforge.ZipForge.file;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static java.nio.file.StandardOpenOption.WRITE;


### PR DESCRIPTION
### What's in here
Addresses https://github.com/helpermethod/zip-forge/issues/43
Changed package name from zip_forge to zipforge in the code and README.md files.